### PR TITLE
Create annotated tags in Omeka-S sync workflow

### DIFF
--- a/.github/workflows/check-omeka-s-version.yml
+++ b/.github/workflows/check-omeka-s-version.yml
@@ -38,6 +38,12 @@ jobs:
           GH_PAT: ${{ secrets.GH_PAT }}
           omeka_tags: ${{ env.omeka_tags }}
         run: |
+          # Annotated tags carry their own creation date, so the release shows
+          # when it was actually cut (Omeka S release day) instead of inheriting
+          # the date of whatever commit main happens to point at.
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
           PROCESSED=0
 
           for tag in $omeka_tags; do
@@ -47,7 +53,7 @@ jobs:
             fi
 
             echo "Creating new tag: $tag"
-            git tag "$tag"
+            git tag -a "$tag" -m "Omeka S $tag"
             git push origin "$tag"
 
             echo "Triggering build for tag $tag"


### PR DESCRIPTION
## Problema

El workflow `Sync Omeka-S Tags` crea tags **lightweight** (`git tag "$tag"`). Un tag lightweight no tiene fecha propia: git y GitHub muestran la fecha del *commit* al que apunta.

Como `main` no cambia entre releases de infraestructura, cada nuevo release sincronizado (p. ej. `v4.2.1`, publicado upstream el 18-jun-2026) apuntaba al último commit de `main` (`6656ed2`, del 9-mar-2026) y **aparecía fechado en marzo**, dando la impresión de que el tag se había hecho mal.

## Arreglo

- Crear tags **anotados** (`git tag -a -m`), que llevan su propia fecha de creación → el release muestra el día real en que se cortó.
- Añadir identidad git (`github-actions[bot]`), requerida para tags anotados en CI.

El tag `v4.2.1` ya existente se re-emitió manualmente como anotado con la fecha real del release (no se modifica su contenido: mismo commit, misma imagen Docker con Omeka S 4.2.1).